### PR TITLE
Fix: Include Broadcast Register Receiver flag

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -1,6 +1,7 @@
 package com.github.yamill.orientation;
 
 import android.app.Activity;
+import android.os.Build;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -150,7 +151,14 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
             FLog.e(ReactConstants.TAG, "no activity to register receiver");
             return;
         }
-        activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
+
+        // After Android API 34 flag indicates whether the broadcast can be received by components of other applications
+        // is required to be set explicitly https://developer.android.com/about/versions/14/behavior-changes-14?hl=pt-br#runtime-receivers-exported
+        if (Build.VERSION.SDK_INT >= 34) {
+            activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"), Context.RECEIVER_NOT_EXPORTED);
+        } else {
+            activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
+        }
     }
     @Override
     public void onHostPause() {


### PR DESCRIPTION
Context
Starting from Android API 34, it is mandatory to explicitly set whether a BroadcastReceiver can be accessed by other applications. This change is aimed at improving security and clarifying the behavior of receivers within the system.

Change
This PR adds the Context.RECEIVER_NOT_EXPORTED flag to the receiver that listens for configuration changes in the onConfigurationChanged method. Since this broadcast is only used internally by the app, it does not need to be accessible to other applications. The flag ensures that only internal components can listen to this broadcast, maintaining the expected behavior.

Compatibility
For devices running API levels below 34, the original behavior remains unchanged, as the explicit flag is only relevant starting from API 34.

Reference
[Documentation on Android 14 changes](https://developer.android.com/about/versions/14/behavior-changes-14?hl=en#runtime-receivers-exported)